### PR TITLE
Add conditions on messagecount

### DIFF
--- a/check_mailbox.sh
+++ b/check_mailbox.sh
@@ -148,7 +148,7 @@ if [ $imap -eq 0 ]; then
 else
   body=$(eval curl --url "$fqhost" -X $commandarg $credentialarg -s --max-time $maxwait $sslarg $insecurearg $verbosearg)
   status=$?
-  body=$(echo "$body" | head -1 | cut -d " " -f2)
+  body=$(echo "$body" | grep "EXISTS" | head -1 | cut -d " " -f2)
 fi
 
 end=$(echo $(($(date +%s%N)/1000000)))

--- a/check_mailbox.sh
+++ b/check_mailbox.sh
@@ -211,21 +211,21 @@ getCode () {
 #decide output by return code
 if [ $status -eq 0 ] ; then
   if (( $messagecount < $min_messages || $max_messages < $messagecount )) ; then
-    echo "CRITICAL: $messagecount messages are in inbox, expected between $min_messages and $max_messages | runtime="$runtime"ms;$warning;$critical;0;$critical messagecount=$messagecount"
+    echo "CRITICAL: $messagecount messages are in inbox, expected between $min_messages and $max_messages | runtime="$runtime"ms;$warning;$critical;0;$critical messagecount=$messagecount;$max_messages;$max_messages;$min_messages;$max_messages"
     exit 2;
   fi;
   if [ $runtime -gt $critical ] ; then
-    echo "CRITICAL: runtime "$runtime" bigger than critical runtime '"$critical"' | runtime="$runtime"ms;$warning;$critical;0;$critical messagecount=$messagecount"
+    echo "CRITICAL: runtime "$runtime" bigger than critical runtime '"$critical"' | runtime="$runtime"ms;$warning;$critical;0;$critical messagecount=$messagecount;$max_messages;$max_messages;$min_messages;$max_messages"
     exit 2;
   fi;
   if [ $runtime -gt $warning ] ; then
-    echo "WARNING: runtime "$runtime" bigger than warning runtime '"$warning"' | runtime="$runtime"ms;$warning;$critical;0;$critical messagecount=$messagecount"
+    echo "WARNING: runtime "$runtime" bigger than warning runtime '"$warning"' | runtime="$runtime"ms;$warning;$critical;0;$critical messagecount=$messagecount;$max_messages;$max_messages;$min_messages;$max_messages"
     exit 1;
   fi;
-  echo "OK: MAILBOX LIST in "$runtime" ms | runtime="$runtime"ms;$warning;$critical;0;$critical messagecount=$messagecount"
+  echo "OK: MAILBOX LIST in "$runtime" ms | runtime="$runtime"ms;$warning;$critical;0;$critical messagecount=$messagecount;$max_messages;$max_messages;$min_messages;$max_messages"
   exit 0;
 else
   message=$(getCode $status)
-  echo "CRITICAL: MAILBOX LIST failed with return code '"$status"' = '"$message"' in "$runtime" ms | runtime="$runtime"ms;$warning;$critical;0;$critical messagecount=$messagecount"
+  echo "CRITICAL: MAILBOX LIST failed with return code '"$status"' = '"$message"' in "$runtime" ms | runtime="$runtime"ms;$warning;$critical;0;$critical messagecount=$messagecount;$max_messages;$max_messages;$min_messages;$max_messages"
   exit 2;
 fi;


### PR DESCRIPTION
This MR adds 2 flags controlling the expected number of mails in the inbox.

It also fixes a count bug, when the IMAP server replies with lines (such as FLAGS) before a line containing the number of emails.